### PR TITLE
Add jalleg Java binding link

### DIFF
--- a/en/bindings/bindings
+++ b/en/bindings/bindings
@@ -24,6 +24,9 @@ to contact the webmaster and report the change.
 [go-allegro]
 :   Go binding to Allegro 5 by Damien Radtke.
 
+[jalleg]
+:   Java binding to Allegro 5.2 by Jason Winnebeck.
+
 Python
 :   The Allegro 5 distribution comes with a basic Python wrapper;
     see the `python` directory.

--- a/en/bindings/links
+++ b/en/bindings/links
@@ -22,6 +22,8 @@
 
 [go-allegro]: https://github.com/dradtke/go-allegro
 
+[jalleg]: https://github.com/gillius/jalleg
+
 [LuAllegro]:	http://luallegro.luaforge.net/
 [Lua]:		http://www.lua.org/
 


### PR DESCRIPTION
I feel that the jalleg binding is complete enough now to list as something for people to actually use with Allegro.
