### PR TITLE
OCaml bindings and broken mailing lists

### DIFF
--- a/en/bindings/bindings
+++ b/en/bindings/bindings
@@ -4,8 +4,8 @@ Although Allegro is written in C and C++, and is mainly designed to be used
 from such, it's possible to use Allegro from other programming languages.
 
 If you would like to add a link to this page, or there is a dead link which
-should be fixed/removed, please use the address given at the bottom of the page
-to contact the webmaster and report the change. 
+should be fixed/removed, please submit a pull request on the
+[website's repository][website_repository].
 
 # Bindings for Allegro 5
 
@@ -13,7 +13,7 @@ to contact the webmaster and report the change.
 :   Lua binding to Allegro 5 by Trezker.
 
 [lallegro]
-:   Lua binding for Allegro 5.2 by gilzoide
+:   Lua binding for Allegro 5.2 by gilzoide.
 
 [AllegroDotNet]
 :   C# bindings for Allegro 5 by Sub-C.
@@ -34,15 +34,18 @@ to contact the webmaster and report the change.
 :   Java binding to Allegro 5.2 by Jason Winnebeck.
 
 [jllegro]
-:   Java Allegro wrapper by Mitchell Larson
+:   Java Allegro wrapper by Mitchell Larson.
 
-Python
-:   The Allegro 5 distribution comes with a basic Python wrapper;
-    see the `python` directory.
+[OCaml Allegro 5]
+:   OCaml binding to Allegro 5 by Sylvain Chiron.
 
 [Allegro.pas]
 :   Allegro.pas is a wrapper to use Allegro with Pascal compilers
     like [Delphi] or [Free Pascal].
+
+Python
+:   The Allegro 5 distribution comes with a basic Python wrapper;
+    see the `python` directory.
 
 [RustAllegro]
 :   Rust wrapper to Allegro 5 by SiegeLord.
@@ -120,6 +123,11 @@ Python
     Allegro and AllegroGL for the Mercury programming language. It's available as
     part of the mercury-extras ROTD (release-of-the-day) distributions on the
     Mercury web site. 
+
+## OCaml
+
+[OCaml Allegro]
+:   An OCaml interface to Allegro written by Florent Monnier.
 
 ## Pascal
 

--- a/en/bindings/links
+++ b/en/bindings/links
@@ -1,3 +1,5 @@
+[website_repository]: https://github.com/liballeg/allegrowww2
+
 [allua]:	https://github.com/trezker/allua
 
 [lallegro]:	https://github.com/gilzoide/lallegro
@@ -33,6 +35,9 @@
 [Lua]:		https://www.lua.org/
 
 [Mercury]:	https://web.archive.org/web/20090310031338/http://www.cs.mu.oz.au/research/mercury/
+
+[OCaml Allegro 5]: https://github.com/Frigory33/ocaml-allegro-5
+[OCaml Allegro]: https://github.com/fccm/ocaml-allegro
 
 [Allegro.pas]:	https://allegro-pas.sourceforge.net/
 [Delphi]:	https://www.embarcadero.com/products/delphi/features/delphi

--- a/en/maillist/maillist
+++ b/en/maillist/maillist
@@ -1,11 +1,11 @@
 # Mailing lists
 
 There have been several mailing lists related to Allegro in the past.
-As of 2015, only the developer's mailing list is really used.
+As of 2025, they are no longer used.
 
-For general discussion you are encouraged to use the
-[Allegro.cc forums](http://www.allegro.cc/forums/) or the
-[Discord server](https://discord.gg/f3Cd4TZzpp).
+You should rather contact us on the
+[Discord server](https://discord.gg/f3Cd4TZzpp) or via a pull request or
+a bug report on GitHub.
 
 [1s]: http://lists.sourceforge.net/lists/listinfo/alleg-main/
 [1a]: http://sourceforge.net/mailarchive/forum.php?forum_name=alleg-main


### PR DESCRIPTION
Hello.

The first commit is to add 2 OCaml bindings to the Language bindings page.

The second one is an update to the Mailing lists page to say that they no longer work, and that communication works better on Discord and GitHub. The link to the Allegro.cc forum is also removed because it is broken.